### PR TITLE
Fix image upload template missing user parameter

### DIFF
--- a/src/routes/galleries.rs
+++ b/src/routes/galleries.rs
@@ -108,6 +108,7 @@ pub async fn post_img(
     context.insert("caption", &img_upload.caption);
     context.insert("gallery_id", &gallery_id);
     context.insert("image_id", &image.id);
+    context.insert("user", writer_session.user());
 
     let image_item = tera_utils::render_template_with_logging("image_item.html", &context)?;
 

--- a/templates/image_item.html
+++ b/templates/image_item.html
@@ -1,2 +1,2 @@
 {% import "macros.html" as macros %}
-{{ macros::image_item(path=path, caption=caption, image_id=image_id, gallery_id=gallery_id) }}
+{{ macros::image_item(path=path, caption=caption, image_id=image_id, gallery_id=gallery_id, user=user) }}


### PR DESCRIPTION
Updated post_img route to include user in template context and modified image_item.html template to pass user parameter to the image_item macro.

Fixes template render error: "Macro image_item is missing the argument user"
